### PR TITLE
removes a forbidden trailing Comma in the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/encryption": "^5.6|^5.7",
         "illuminate/http": "^5.6|^5.7",
         "illuminate/support": "^5.6|^5.7",
-        "illuminate/validation": "^5.6|^5.7",
+        "illuminate/validation": "^5.6|^5.7"
     },
     "require-dev": {
         "orchestra/testbench": "^3.6|^3.7",


### PR DESCRIPTION
Removes a trailing Comma from the composer.json, which made the config invalid.
This comma was added with the commit a66fb9d (even though it was a WIP-Commit).

(PS.: was on my way to fix #20 but @alex26raider beat me to it. Hope this is also a valid PR 😃)