### PR TITLE
Add class configuration

### DIFF
--- a/config/honeypot.php
+++ b/config/honeypot.php
@@ -5,6 +5,12 @@ use Spatie\Honeypot\SpamResponder\BlankPageResponder;
 return [
 
     /*
+     * Here you can specify classes of the honeypot wrapper.
+     * If no class name is provided inline display none will be used.
+     */
+    'classes' => null,
+
+    /*
      * Here you can specify name of the honeypot field. Any requests that submit a non-empty
      * value for this name will be discarded. Make sure this name does not
      * collide with a form field that is actually used.

--- a/resources/views/honeypotFormFields.blade.php
+++ b/resources/views/honeypotFormFields.blade.php
@@ -1,5 +1,5 @@
 @if($enabled)
-    <div id="{{ $nameFieldName }}_wrap" style="display:none;">
+    <div id="{{ $nameFieldName }}_wrap" {!! $classes ? 'class="' . $classes . '"' : 'style="display:none;"' !!}>
         <input name="{{ $nameFieldName }}" type="text" value="" id="{{ $nameFieldName }}">
         <input name="{{ $validFromFieldName }}" type="text" value="{{ $encryptedValidFrom }}">
     </div>

--- a/src/HoneypotViewComposer.php
+++ b/src/HoneypotViewComposer.php
@@ -25,11 +25,14 @@ class HoneypotViewComposer
             $nameFieldName = sprintf('%s_%s', $nameFieldName, Str::random());
         }
 
+        $classes = $honeypotConfig['classes'];
+
         $view->with(compact(
             'enabled',
             'nameFieldName',
             'validFromFieldName',
-            'encryptedValidFrom'
+            'encryptedValidFrom',
+            'classes'
         ));
     }
 }


### PR DESCRIPTION
Add option to set custom class to wrapper div. Many of bots are just ignoring input elements when they are hidden (ie display none).

Providing this option developers will be able to change visual of wrapper (set position, text intend etc, whatever they want).

Since we cant use id selector with `randomize_name_field_name` set to `true`, I made this PR.

Thanks.