### PR TITLE
Fix Composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/contracts": "~5.7|~5.8",
-        "illuminate/encryption": "~5.7|~5.8",
-        "illuminate/http": "~5.7|~5.8",
-        "illuminate/support": "~5.7|~5.8",
-        "illuminate/validation": "~5.7|~5.8"
+        "illuminate/contracts": "5.7.*|5.8.*",
+        "illuminate/encryption": "5.7.*|5.8.*",
+        "illuminate/http": "5.7.*|5.8.*",
+        "illuminate/support": "5.7.*|5.8.*",
+        "illuminate/validation": "5.7.*|5.8.*"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.7|~3.8",
-        "phpunit/phpunit": "^8.0",
+        "orchestra/testbench": "3.7.*|3.8.*",
+        "phpunit/phpunit": "^7.3|^8.0",
         "spatie/phpunit-snapshot-assertions": "^2.0"
     },
     "autoload": {
@@ -41,7 +41,6 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
-
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Composer treats tilde ranges differently than NPM. For Composer, `~5.7` will match `>=5.7 <6.0.0)`. (https://getcomposer.org/doc/articles/versions.md#tilde-version-range-) As a result, automated tests do not currently cover Laravel 5.7.

This also re-allows PHPUnit 7 because Testbench 3.7 requires it.