### PR TITLE
Switch to CarbonInterface

### DIFF
--- a/src/EncryptedTime.php
+++ b/src/EncryptedTime.php
@@ -2,14 +2,14 @@
 
 namespace Spatie\Honeypot;
 
-use Carbon\Carbon;
+use Carbon\CarbonInterface;
 
 class EncryptedTime
 {
     /** @var string */
     protected $encryptedTime;
 
-    public static function create(Carbon $carbon)
+    public static function create(CarbonInterface $carbon)
     {
         $encryptedTime = app('encrypter')->encrypt($carbon->timestamp);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Spatie\Honeypot\Tests;
 
 use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Illuminate\Support\Facades\View;
 use Spatie\Honeypot\HoneypotServiceProvider;
 use Spatie\Honeypot\Tests\TestClasses\FakeEncrypter;
@@ -30,7 +31,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function setNow($year, int $month = 1, int $day = 1)
     {
-        $newNow = $year instanceof Carbon
+        $newNow = $year instanceof CarbonInterface
             ? $year
             : Carbon::createFromDate($year, $month, $day);
 


### PR DESCRIPTION
In Laravel 5.8 (or those of us using Carbon v2), some of us may be forcing the use of CarbonImmutable throughout our Laravel application with `Date::use(CarbonImmutable::class)` in our AppServiceProvider register() for example.

Hence it will be better if we are expecting `CarbonInterface` instead of expecting `Carbon`. If not an error like this will be thrown:

```
Argument 1 passed to Spatie\Honeypot\EncryptedTime::create() must be an instance of Carbon\Carbon, instance of Carbon\CarbonImmutable given
```