### PR TITLE
allow configuration via env variables

### DIFF
--- a/config/honeypot.php
+++ b/config/honeypot.php
@@ -3,33 +3,32 @@
 use Spatie\Honeypot\SpamResponder\BlankPageResponder;
 
 return [
-
     /*
      * Here you can specify name of the honeypot field. Any requests that submit a non-empty
      * value for this name will be discarded. Make sure this name does not
      * collide with a form field that is actually used.
      */
-    'name_field_name' => 'my_name',
+    'name_field_name' => env('HONEYPOT_NAME', 'my_name'),
 
     /*
      * When this is activated there will be a random string added
      * to the name_field_name. This improves the
      * protection against bots.
      */
-    'randomize_name_field_name' => true,
+    'randomize_name_field_name' => env('HONEYPOT_RANDOMIZE', true),
 
     /*
      * This field contains the name of a form field that will be used to verify
      * if the form wasn't submitted too quickly. Make sure this name does not
      * collide with a form field that is actually used.
      */
-    'valid_from_field_name' => 'valid_from',
+    'valid_from_field_name' => env('HONEYPOT_VALID_FROM', 'valid_from'),
 
     /*
      * If the form is submitted faster then this amount of seconds
      * the form submission will be considered invalid.
      */
-    'amount_of_seconds' => 1,
+    'amount_of_seconds' => env('HONEYPOT_SECONDS', 1),
 
     /*
      * This class is responsible for sending a response to request that
@@ -43,5 +42,5 @@ return [
     /*
      * This switch determines if the honeypot protection should be activated.
      */
-    'enabled' => true,
+    'enabled' => env('HONEYPOT_ENABLED', true),
 ];


### PR DESCRIPTION
Allow configuration via env variables, makes it easier to configure test environments using something like the phpunit.xml for env variables.