### PR TITLE
fix: fix random fields with no honeypot failing

### DIFF
--- a/src/EncryptedTime.php
+++ b/src/EncryptedTime.php
@@ -25,6 +25,10 @@ class EncryptedTime
 
         $timestamp = app('encrypter')->decrypt($encryptedTime);
 
+        if (! $this->isValidTimeStamp($timestamp)) {
+            throw new \Exception(sprintf('Timestamp %s is invalid', $timestamp));
+        }
+
         $this->carbon = Date::createFromTimestamp($timestamp);
     }
 
@@ -36,5 +40,12 @@ class EncryptedTime
     public function __toString()
     {
         return $this->encryptedTime;
+    }
+
+    private function isValidTimeStamp(string $timestamp)
+    {
+        return ((string) (int) $timestamp === $timestamp)
+            && ($timestamp >= 0)
+            && ($timestamp <= PHP_INT_MAX);
     }
 }

--- a/src/ProtectAgainstSpam.php
+++ b/src/ProtectAgainstSpam.php
@@ -3,6 +3,7 @@
 namespace Spatie\Honeypot;
 
 use Closure;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Spatie\Honeypot\SpamResponder\SpamResponder;
@@ -35,10 +36,6 @@ class ProtectAgainstSpam
 
         $honeypotValue = $request->get($nameFieldName);
 
-        if (is_null($nameFieldName)) {
-            return $this->respondToSpam($request, $next);
-        }
-
         if (! empty($honeypotValue)) {
             return $this->respondToSpam($request, $next);
         }
@@ -61,7 +58,7 @@ class ProtectAgainstSpam
     private function getRandomizedNameFieldName($nameFieldName, $requestFields):?String
     {
         return collect($requestFields)->filter(function ($value, $key) use ($nameFieldName) {
-            return starts_with($key, $nameFieldName);
+            return Str::startsWith($key, $nameFieldName);
         })->keys()->first();
     }
 

--- a/tests/ProtectAgainstSpamTest.php
+++ b/tests/ProtectAgainstSpamTest.php
@@ -38,9 +38,19 @@ class ProtectAgainstSpamTest extends TestCase
     }
 
     /** @test */
-    public function requests_that_not_use_the_honeypot_fields_succeed()
+    public function requests_that_not_use_the_honeypot_fields_succeed_without_random_name()
     {
         config()->set('honeypot.randomize_name_field_name', false);
+
+        $this
+            ->post('test')
+            ->assertPassedSpamProtection();
+    }
+
+    /** @test */
+    public function requests_that_not_use_the_honeypot_fields_succeed_with_random_name()
+    {
+        config()->set('honeypot.randomize_name_field_name', true);
 
         $this
             ->post('test')
@@ -128,19 +138,11 @@ class ProtectAgainstSpamTest extends TestCase
     }
 
     /** @test */
-    public function submission_with_random_generated_name_without_correct_prefix_will_be_marked_as_spam()
+    public function submissions_that_are_posted_with_invalid_payload_will_be_marked_as_spam()
     {
         config()->set('honeypot.randomize_name_field_name', true);
 
-        $this
-            ->post('test')
-            ->assertDidNotPassSpamProtection();
-    }
-
-    /** @test */
-    public function submissions_that_are_posted_with_invalid_payload_will_be_marked_as_spam()
-    {
-        $nameField = config('honeypot.name_field_name');
+        $nameField = config('honeypot.name_field_name').Str::random();
         $validFromField = config('honeypot.valid_from_field_name');
 
         $validFrom = 'SomeRandomString';


### PR DESCRIPTION
Issue: #34 

So I had a look into this. It[ fails here](https://github.com/spatie/laravel-honeypot/blob/master/src/ProtectAgainstSpam.php#L38-L40) because when randomised field names are turned on the `getRandomizedNameFieldName` method returns null when there are no fields. 

From what I can understand from reading the package docs, is this is incorrect. It should only fail when the field is present and filled, so i've modified the behaviour to this.

After doing this, I also discovered another issue, where a invalid timestamp was being parsed by carbon, but no exception was thrown. Instead, it returned a instance for the timestamp `0` ie 1970 which causes the response to be marked as valid as it fails `isFuture` (see screenshot below).

I've fixed this by adding a simple verification to ensure that time timestamp is indeed valid.

![image](https://user-images.githubusercontent.com/50683531/59315019-35df0900-8cfb-11e9-89bb-73455713914d.png)

