### PR TITLE
Block requests if no honeypot fields are present

### DIFF
--- a/src/ProtectAgainstSpam.php
+++ b/src/ProtectAgainstSpam.php
@@ -45,17 +45,19 @@ class ProtectAgainstSpam
             return $this->respondToSpam($request, $next);
         }
 
-        if ($validFrom = $request->get(config('honeypot.valid_from_field_name'))) {
-            try {
-                $time = new EncryptedTime($validFrom);
-            } catch (Exception $decryptException) {
-                $time = null;
-            }
+        $validFrom = $request->get(config('honeypot.valid_from_field_name'));
 
-            if (! $time || $time->isFuture()) {
-                return $this->respondToSpam($request, $next);
-            }
-        } else {
+        if (! $validFrom) {
+            return $this->respondToSpam($request, $next);
+        }
+
+        try {
+            $time = new EncryptedTime($validFrom);
+        } catch (Exception $decryptException) {
+            $time = null;
+        }
+
+        if (! $time || $time->isFuture()) {
             return $this->respondToSpam($request, $next);
         }
 

--- a/src/ProtectAgainstSpam.php
+++ b/src/ProtectAgainstSpam.php
@@ -35,6 +35,10 @@ class ProtectAgainstSpam
             $nameFieldName = $this->getRandomizedNameFieldName($nameFieldName, $request->all());
         }
 
+        if (! $request->has($nameFieldName)) {
+            return $this->respondToSpam($request, $next);
+        }
+
         $honeypotValue = $request->get($nameFieldName);
 
         if (! empty($honeypotValue)) {
@@ -51,6 +55,8 @@ class ProtectAgainstSpam
             if (! $time || $time->isFuture()) {
                 return $this->respondToSpam($request, $next);
             }
+        } else {
+            return $this->respondToSpam($request, $next);
         }
 
         return $next($request);


### PR DESCRIPTION
As I pointed out in #51 the request is also valid if no honeypot fields are POSTed at all. This PR fixes that. I also fixed the tests accordingly.

Maybe this should be considered a breaking change as some people may be relying on not including the `@honeypot` directive in all forms but using the middleware on all requests.