### PR TITLE
Adds a HoneypotSetup class

### DIFF
--- a/src/HoneypotSetup.php
+++ b/src/HoneypotSetup.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spatie\Honeypot;
+
+use Illuminate\Support\Str;
+use Spatie\Honeypot\EncryptedTime;
+
+class HoneypotSetup
+{
+    /**
+     * Get an array with values needed for composing the view
+     * It allows to use it outside a blade component so it
+     * can be passed to a front-end framework like vue
+     *
+     * @return array
+     */
+    public static function get()
+    {
+
+        $honeypotConfig = config('honeypot');
+
+        $nameFieldName = $honeypotConfig['name_field_name'];
+
+        $randomNameFieldName = $honeypotConfig['randomize_name_field_name'];
+        $enabled = $honeypotConfig['enabled'];
+        $validFromFieldName = $honeypotConfig['valid_from_field_name'];
+
+        $validFrom = now()->addSeconds($honeypotConfig['amount_of_seconds']);
+
+        $encryptedValidFrom = EncryptedTime::create($validFrom);
+
+        if ($randomNameFieldName) {
+            $nameFieldName = sprintf('%s_%s', $nameFieldName, Str::random());
+        }
+
+        return [
+            'enabled' => $enabled,
+            'nameFieldName' => $nameFieldName,
+            'validFromFieldName' => $validFromFieldName,
+            'encryptedValidFrom' => strval($encryptedValidFrom)
+        ];
+    }
+}

--- a/src/HoneypotViewComposer.php
+++ b/src/HoneypotViewComposer.php
@@ -2,34 +2,20 @@
 
 namespace Spatie\Honeypot;
 
-use Illuminate\Support\Str;
+
 use Illuminate\View\View;
+use Spatie\Honeypot\HoneypotSetup;
 
 class HoneypotViewComposer
 {
     public function compose(View $view)
     {
-        $honeypotConfig = config('honeypot');
 
-        $nameFieldName = $honeypotConfig['name_field_name'];
+        $fields = HoneypotSetup::get();
 
-        $randomNameFieldName = $honeypotConfig['randomize_name_field_name'];
-        $enabled = $honeypotConfig['enabled'];
-        $validFromFieldName = $honeypotConfig['valid_from_field_name'];
-
-        $validFrom = now()->addSeconds($honeypotConfig['amount_of_seconds']);
-
-        $encryptedValidFrom = EncryptedTime::create($validFrom);
-
-        if ($randomNameFieldName) {
-            $nameFieldName = sprintf('%s_%s', $nameFieldName, Str::random());
-        }
-
-        $view->with(compact(
-            'enabled',
-            'nameFieldName',
-            'validFromFieldName',
-            'encryptedValidFrom'
-        ));
+        $view->with('enabled', $fields['enabled'])
+            ->with('nameFieldName', $fields['nameFieldName'])
+            ->with('validFromFieldName', $fields['validFromFieldName'])
+            ->with('encryptedValidFrom', $fields['encryptedValidFrom']);
     }
 }

--- a/tests/HoneypotSetupTest.php
+++ b/tests/HoneypotSetupTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Spatie\Honeypot\Tests;
+
+use Illuminate\Support\Str;
+use Spatie\Honeypot\HoneypotSetup;
+
+class HoneypotSetupTest extends TestCase
+{
+
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /** @test */
+    public function honeypot_setup_returns_enabled_true_if_true_in_config()
+    {
+        config()->set('honeypot.enabled', true);
+
+        $this->assertTrue(HoneypotSetup::get()['enabled']);
+    }
+
+    /** @test */
+    public function honeypot_setup_returns_enabled_false_if_false_in_config()
+    {
+        config()->set('honeypot.enabled', false);
+
+        $this->assertFalse(HoneypotSetup::get()['enabled']);
+    }
+
+    /** @test */
+    public function honeypot_setup_returns_correct_name_field_name_when_randomize_name_field_name_is_false()
+    {
+        config()->set('honeypot.name_field_name', 'test_field');
+        config()->set('honeypot.randomize_name_field_name', false);
+        $this->assertEquals(HoneypotSetup::get()['nameFieldName'], 'test_field');
+    }
+
+    /** @test */
+    public function honeypot_setup_returns_correct_name_field_name_when_randomize_name_field_name_is_true()
+    {
+        config()->set('honeypot.name_field_name', 'test_field');
+        config()->set('honeypot.randomize_name_field_name', true);
+
+        $nameFieldName = HoneypotSetup::get()['nameFieldName'];
+
+        $this->assertTrue(Str::of($nameFieldName)->startsWith('test_field_'));
+
+        $this->assertTrue(Str::of($nameFieldName)->length() > 11);
+    }
+
+    /** @test */
+    public function honeypot_setup_returns_correct_valid_from_field_name()
+    {
+        config()->set('honeypot.valid_from_field_name', 'test_from_field');
+
+        $this->assertEquals(HoneypotSetup::get()['validFromFieldName'], 'test_from_field');
+    }
+
+    /** @test */
+    public function honeypot_setup_returns_an_encrypted_time()
+    {
+        $this->assertTrue(Str::of(HoneypotSetup::get()['encryptedValidFrom'])->length() > 0);
+    }
+}


### PR DESCRIPTION
Adds a HoneypotSetup class allowing to easily get an array with all honeypot setup outside Laravel Blade (ie. in a controller) so it can be easily passed to front-end frameworks. This PR doesn't induce any breaking change. 

BTW: **Thanks for nice package (and all others from Spatie)!**

Here is an example (use case) with inertiajs and vue:

```php
// In the controller
use Inertia\Inertia;
use Spatie\Honeypot\HoneypotSetup;
(...)
public function showRegistrationForm()
{
    return Inertia::render('Register', [
        'honeypot' => HoneypotSetup::get()
    ]);
}
```
```javascript
// In the Register vue component
<template>
(...)
  <form @submit.prevent="onSubmit">
  (...)
    <div style="display:none;" v-if="honeypot.enabled">
       <input
          ref="honey-input"
          :name="honeypot.nameFieldName"
          type="text"
          :id="honeypot.nameFieldName"
        />
    </div>
  (...)
  </form>
(...)
</template>
<script>
export default {
  props: {
    honeypot: Object
  },
  data() {
    return {
      form: {
        first_name: ""
      }
    };
  },
  methods: {
    onSubmit() {
      if (this.honeypot.enabled) {
        this.form[this.honeypot.nameFieldName] = this.$refs["honeypot-input"].value;
        this.form[this.honeypot.validFromFieldName] = this.honeypot.encryptedValidFrom;
      }
      this.$inertia.post("/register", this.form)
    }
  }
};
</script>
```