### PR TITLE
add option to skip timestamp check

### DIFF
--- a/config/honeypot.php
+++ b/config/honeypot.php
@@ -18,6 +18,12 @@ return [
     'randomize_name_field_name' => env('HONEYPOT_RANDOMIZE', true),
 
     /*
+     * When this is activated, requests will be checked if
+     * form is submitted faster than this amount of seconds
+     */
+    'valid_from_timestamp' => env('HONEYPOT_VALID_FROM_TIMESTAMP', true),
+
+    /*
      * This field contains the name of a form field that will be used to verify
      * if the form wasn't submitted too quickly. Make sure this name does not
      * collide with a form field that is actually used.

--- a/src/ProtectAgainstSpam.php
+++ b/src/ProtectAgainstSpam.php
@@ -9,23 +9,21 @@ use Illuminate\Support\Str;
 use Spatie\Honeypot\SpamResponder\SpamResponder;
 use Symfony\Component\HttpFoundation\Response;
 
-class ProtectAgainstSpam
-{
+class ProtectAgainstSpam {
+
     /** @var \Spatie\Honeypot\SpamResponder\SpamResponder */
     protected $spamResponder;
 
-    public function __construct(SpamResponder $spamResponder)
-    {
+    public function __construct(SpamResponder $spamResponder) {
         $this->spamResponder = $spamResponder;
     }
 
-    public function handle(Request $request, Closure $next): Response
-    {
-        if (! config('honeypot.enabled')) {
+    public function handle(Request $request, Closure $next): Response {
+        if (!config('honeypot.enabled')) {
             return $next($request);
         }
 
-        if (! $request->isMethod('POST')) {
+        if (!$request->isMethod('POST')) {
             return $next($request);
         }
 
@@ -35,55 +33,53 @@ class ProtectAgainstSpam
             $nameFieldName = $this->getRandomizedNameFieldName($nameFieldName, $request->all());
         }
 
-        if (! $this->shouldCheckHoneypot($request, $nameFieldName)) {
+        if (!$this->shouldCheckHoneypot($request, $nameFieldName)) {
             return $next($request);
         }
 
-        if (! $request->has($nameFieldName)) {
+        if (!$request->has($nameFieldName)) {
             return $this->respondToSpam($request, $next);
         }
 
         $honeypotValue = $request->get($nameFieldName);
 
-        if (! empty($honeypotValue)) {
+        if (!empty($honeypotValue)) {
             return $this->respondToSpam($request, $next);
         }
 
         $validFrom = $request->get(config('honeypot.valid_from_field_name'));
 
-        if (! $validFrom) {
+        if (!$validFrom) {
             return $this->respondToSpam($request, $next);
         }
 
-        try {
-            $time = new EncryptedTime($validFrom);
-        } catch (Exception $decryptException) {
-            $time = null;
-        }
+        if (config('honeypot.valid_from_timestamp')) {
+            try {
+                $time = new EncryptedTime($validFrom);
+            } catch (Exception $decryptException) {
+                $time = null;
+            }
 
-        if (! $time || $time->isFuture()) {
-            return $this->respondToSpam($request, $next);
+            if (!$time || $time->isFuture()) {
+                return $this->respondToSpam($request, $next);
+            }
         }
-
         return $next($request);
     }
 
-    private function getRandomizedNameFieldName($nameFieldName, $requestFields): ?String
-    {
+    private function getRandomizedNameFieldName($nameFieldName, $requestFields): ?string {
         return collect($requestFields)->filter(function ($value, $key) use ($nameFieldName) {
             return Str::startsWith($key, $nameFieldName);
         })->keys()->first();
     }
 
-    protected function respondToSpam(Request $request, Closure $next): Response
-    {
+    protected function respondToSpam(Request $request, Closure $next): Response {
         event(new SpamDetected($request));
 
         return $this->spamResponder->respond($request, $next);
     }
 
-    private function shouldCheckHoneypot(Request $request, ?string $nameFieldName): bool
-    {
+    private function shouldCheckHoneypot(Request $request, ?string $nameFieldName): bool {
         if (config('honeypot.honeypot_fields_required_for_all_forms') == true) {
             return true;
         }

--- a/tests/ProtectAgainstSpamTest.php
+++ b/tests/ProtectAgainstSpamTest.php
@@ -138,6 +138,32 @@ class ProtectAgainstSpamTest extends TestCase
     }
 
     /** @test */
+    public function submissions_that_are_posted_after_or_on_valid_from_will_not_be_marked_as_spam_timestampcheck_is_disabled()
+    {
+        config()->set('honeypot.valid_from_timestamp', false);
+        $nameField = config('honeypot.name_field_name');
+        $validFromField = config('honeypot.valid_from_field_name');
+        $validFrom = EncryptedTime::create(now());
+
+        $this
+            ->post('test', [$nameField => '', $validFromField => $validFrom])
+            ->assertPassedSpamProtection();
+    }
+
+    /** @test */
+    public function submissions_that_are_posted_after_or_on_valid_from_will_not_be_marked_as_spam_timestampcheck_is_enabled()
+    {
+        config()->set('honeypot.valid_from_timestamp', true);
+        $nameField = config('honeypot.name_field_name');
+        $validFromField = config('honeypot.valid_from_field_name');
+        $validFrom = EncryptedTime::create(now());
+
+        $this
+            ->post('test', [$nameField => '', $validFromField => $validFrom])
+            ->assertPassedSpamProtection();
+    }
+
+    /** @test */
     public function submissions_that_are_posted_after_or_on_valid_from_will_not_be_marked_as_spam()
     {
         $nameField = config('honeypot.name_field_name');


### PR DESCRIPTION
Sometimes the timestamp check isn't needed, so there should be an option to skip it.

for example if you use honeypot with mailcoach on an external page where you cannot encrypt the timestamp.