### PR TITLE
Update installation publishing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ composer require spatie/laravel-honeypot
 Optionally, you can publish the config file of the package.
 
 ```bash
-php artisan vendor:publish --provider="Spatie\Honeypot\HoneypotServiceProvider" --tag=config
+php artisan vendor:publish --provider="Spatie\Honeypot\HoneypotServiceProvider" --tag=honeypot-config
 ```
 
 This is the content of the config file that will be published at `config/honeypot.php`:


### PR DESCRIPTION
As discussed in #88 this updates the tag name when publishing the vendor assets.