### PR TITLE
Fixing class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ The view will be placed in `resources/views/vendor/honeypot/honeypotFormFields.b
 
 ### Events fired
 
-Whenever spam is detected, the `Spatie\Honeypot|Events\SpamDetectedEvent` event is fired. It has the `$request` as a public property.
+Whenever spam is detected, the `Spatie\Honeypot\Events\SpamDetectedEvent` event is fired. It has the `$request` as a public property.
 
 ### Testing
 


### PR DESCRIPTION
Hello Spatie Team,

I've found this in a code base and was wondering where the pipe came from and found that it might have been copied from the README. Minor issue, but I would still fix it.

Cheers,
Peter