### PR TITLE
handle DecryptException when valid_from field is a non-encrypted valu…

### DIFF
--- a/src/EncryptedTime.php
+++ b/src/EncryptedTime.php
@@ -4,6 +4,7 @@ namespace Spatie\Honeypot;
 
 use Carbon\CarbonInterface;
 use DateTimeInterface;
+use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Support\Facades\Date;
 use Spatie\Honeypot\Exceptions\InvalidTimestamp;
 
@@ -24,7 +25,11 @@ class EncryptedTime
     {
         $this->encryptedTime = $encryptedTime;
 
-        $timestamp = app('encrypter')->decrypt($encryptedTime);
+        try {
+            $timestamp = app('encrypter')->decrypt($encryptedTime);
+        } catch (DecryptException $e) {
+            throw InvalidTimestamp::make($encryptedTime);
+        }
 
         if (! $this->isValidTimeStamp($timestamp)) {
             throw InvalidTimestamp::make($timestamp);

--- a/tests/HoneypotBladeDirectiveTest.php
+++ b/tests/HoneypotBladeDirectiveTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Honeypot\Tests;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Support\DateFactory;
+use Spatie\Honeypot\Tests\TestClasses\FakeEncrypter;
 use Spatie\Snapshots\MatchesSnapshots;
 use Spatie\TestTime\TestTime;
 
@@ -14,6 +15,8 @@ class HoneypotBladeDirectiveTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        $this->swap('encrypter', new FakeEncrypter());
 
         config()->set('honeypot.randomize_name_field_name', false);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,6 @@ use Illuminate\Foundation\Testing\Concerns\InteractsWithContainer;
 use Illuminate\Support\Facades\View;
 use Livewire\LivewireServiceProvider;
 use Spatie\Honeypot\HoneypotServiceProvider;
-use Spatie\Honeypot\Tests\TestClasses\FakeEncrypter;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -20,7 +19,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
         View::addLocation(__DIR__.'/views');
 
-        $this->swap('encrypter', new FakeEncrypter());
+        config()->set('app.key', 'base64:05V7tNPZKeo4DB3PT/Xzgw6qAKxVTAjUWWZ9YrzpBc0=');
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
Addresses a spam bot filling out non-encrypted text into the valid_from field, which was causing an un-caught DecryptException, discussed here:
https://github.com/spatie/laravel-honeypot/discussions/108

The existing tests test for this IF the real encrypter is used, rather than the packages FakeEncrypter, so the tests were modified to use the real encrypter where necessary.

Laravel does validate the key format, so I had to create a fresh real app.key and set this with config()->set.

I took a crack at it, but there is probably a cleaner way to use the real encrypter, open to suggestions.