### PR TITLE
Fixes not dispatching SpamDetectedEvent in Livewire

### DIFF
--- a/src/Http/Livewire/Concerns/UsesSpamProtection.php
+++ b/src/Http/Livewire/Concerns/UsesSpamProtection.php
@@ -4,6 +4,7 @@ namespace Spatie\Honeypot\Http\Livewire\Concerns;
 
 use Livewire\Component;
 use ReflectionProperty;
+use Spatie\Honeypot\Events\SpamDetectedEvent;
 use Spatie\Honeypot\Exceptions\SpamException;
 use Spatie\Honeypot\SpamProtection;
 
@@ -35,6 +36,8 @@ trait UsesSpamProtection
         try {
             app(SpamProtection::class)->check($honeypotData->toArray());
         } catch (SpamException) {
+            event(new SpamDetectedEvent(request()));
+
             abort(403, 'Spam detected.');
         }
     }


### PR DESCRIPTION
I noticed the SpamDetectedEvent event does not dispatch in the Livewire components and in this PR, I have made the required adjustment.

I didn't know whether this was something that should be covered in the test suite. So I figured I should update the tests in a separate commit so that we can cherry-pick the first one if the tests are redundant.

Please tell me if I could do better with the tests.