### PR TITLE
Allow user to define HoneypotDataProperty for functional Volt

### DIFF
--- a/src/Http/Livewire/Concerns/UsesSpamProtection.php
+++ b/src/Http/Livewire/Concerns/UsesSpamProtection.php
@@ -13,6 +13,12 @@ trait UsesSpamProtection
 {
     public function guessHoneypotDataProperty(): ?HoneypotData
     {
+        $property = $this->getHoneyPotDataProperty();
+
+        if ($property) {
+            return $this->$property;
+        }
+
         $props = (new \ReflectionClass($this))
             ->getProperties(ReflectionProperty::IS_PUBLIC);
 
@@ -23,6 +29,11 @@ trait UsesSpamProtection
         }
 
         return null;
+    }
+
+    protected function getHoneyPotDataProperty(): ?string
+    {
+        //
     }
 
     protected function protectAgainstSpam(): void

--- a/src/Http/Livewire/Concerns/UsesSpamProtection.php
+++ b/src/Http/Livewire/Concerns/UsesSpamProtection.php
@@ -13,7 +13,7 @@ trait UsesSpamProtection
 {
     public function guessHoneypotDataProperty(): ?HoneypotData
     {
-        $property = $this->getHoneyPotDataProperty();
+        $property = $this->getHoneypotDataProperty();
 
         if ($property) {
             return $this->$property;
@@ -31,7 +31,7 @@ trait UsesSpamProtection
         return null;
     }
 
-    protected function getHoneyPotDataProperty(): ?string
+    protected function getHoneypotDataProperty(): ?string
     {
         //
     }


### PR DESCRIPTION
Related to https://github.com/spatie/laravel-honeypot/discussions/122

# Problem

We're unable to use the package in Volt using functional syntax

# Cause

The package depends on Reflection to guess the HoneypotData property, by checking which property has the HoneypotData type. Unfortunately, this is incompatible with Volt using functional syntax.

# Solution

Add a method in the `UsesSpamProtection` trait `getHoneypotDataProperty` that allows user to specify which property is the HoneypotData property. If not specified, it falls back to Reflection to guess the property