### PR TITLE
Fix Carbon 3 rawAddUnit type

### DIFF
--- a/config/honeypot.php
+++ b/config/honeypot.php
@@ -39,7 +39,7 @@ return [
      * If the form is submitted faster than this amount of seconds
      * the form submission will be considered invalid.
      */
-    'amount_of_seconds' => env('HONEYPOT_SECONDS', 3),
+    'amount_of_seconds' => (int) env('HONEYPOT_SECONDS', 3),
 
     /*
      * This class is responsible for sending a response to requests that


### PR DESCRIPTION
This PR fixes Carbon 3 support for declaring:

```
HONEYPOT_SECONDS=1
```

Which will return a string instead of int and throw this error:

```
Carbon\Carbon::rawAddUnit(): Argument #3 ($value) must be of type int|float, string given, called in vendor\nesbot\carbon\src\Carbon\Traits\Units.php on line 356
```