### PR TITLE
Corrected publishing tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ composer require spatie/laravel-honeypot
 Optionally, you can publish the config file of the package.
 
 ```bash
-php artisan vendor:publish --provider="Spatie\Honeypot\HoneypotServiceProvider" --tag=honeypot-config
+php artisan vendor:publish --provider="Spatie\Honeypot\HoneypotServiceProvider" --tag=config
 ```
 
 This is the content of the config file that will be published at `config/honeypot.php`:


### PR DESCRIPTION
Attempting to publish a tag of `honeypot-config` results in no publishable resources for tag. Correcting this to `config` publishes the required configuration file.