### PR TITLE
Register components lazily

### DIFF
--- a/src/HoneypotServiceProvider.php
+++ b/src/HoneypotServiceProvider.php
@@ -3,8 +3,6 @@
 namespace Spatie\Honeypot;
 
 use Illuminate\Contracts\View\Factory;
-use Illuminate\Support\Facades\Blade;
-use Illuminate\Support\Facades\View;
 use Illuminate\View\Compilers\BladeCompiler;
 use Spatie\Honeypot\SpamResponder\SpamResponder;
 use Spatie\Honeypot\View\HoneypotComponent;

--- a/src/HoneypotServiceProvider.php
+++ b/src/HoneypotServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace Spatie\Honeypot;
 
+use Illuminate\Contracts\View\Factory;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\View;
+use Illuminate\View\Compilers\BladeCompiler;
 use Spatie\Honeypot\SpamResponder\SpamResponder;
 use Spatie\Honeypot\View\HoneypotComponent;
 use Spatie\Honeypot\View\HoneypotViewComposer;
@@ -38,14 +40,15 @@ class HoneypotServiceProvider extends PackageServiceProvider
         return $this;
     }
 
-    protected function registerBladeClasses(): self
+    protected function registerBladeClasses(): void
     {
-        View::composer('honeypot::honeypotFormFields', HoneypotViewComposer::class);
-        Blade::component('honeypot', HoneypotComponent::class);
-        Blade::directive('honeypot', function () {
-            return "<?php echo view('honeypot::honeypotFormFields'); ?>";
+        $this->callAfterResolving('view', static function (Factory $view) {
+            $view->composer('honeypot::honeypotFormFields', HoneypotViewComposer::class);
         });
 
-        return $this;
+        $this->callAfterResolving('blade.compiler', static function (BladeCompiler $blade) {
+            $blade->component('honeypot', HoneypotComponent::class);
+            $blade->directive('honeypot', static fn () => "<?php echo view('honeypot::honeypotFormFields'); ?>");
+        });
     }
 }


### PR DESCRIPTION
Hi! 👋

I was trying to test a contact form page until a pesky problem reared its head:

```
Illuminate\Contracts\Container\BindingResolutionException: Unresolvable dependency resolving [Parameter #1 [ <required> string $manifestPath ]] in class BladeUI\Icons\IconsManifest
```

Further investigation lead me to laravel-honeypot as the package seems to register its services eagerly. I do recognize not everyone is making use of application siloing (registering only the necessary service providers at the last possible moment), _but_ this change would _also_ benefit every application by becoming a **lazy** service registrar. `callAfterResolving` is a method that has been in the framework since v5.6, so it won't break BC. (Please see [this article](https://muhammedsari.me/dear-laravel-package-authors#under-utilization-of-container-events) for more context).

I have also removed the `$this` return in the last method in the chain of calls, as it was unused.

Thank you! 🙏