### PR TITLE
Support Livewire 4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,12 +38,6 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
 
-      - name: Remove Livewire for unsupported Laravel versions
-        if: matrix.laravel == '13.*'
-        run: |
-          composer remove livewire/livewire pestphp/pest-plugin-livewire --dev --no-interaction --no-update
-          rm -f tests/HoneypotLivewireComponentTest.php
-
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:>=2.72.6" --no-interaction --no-update

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/http-foundation": "^7.0|^8.0"
     },
     "require-dev": {
-        "livewire/livewire": "^3.0",
+        "livewire/livewire": "^3.0|^4.0",
         "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^2.0|^3.0|^4.0",
         "pestphp/pest-plugin-livewire": "^1.0|^2.1|^3.0|^4.0",


### PR DESCRIPTION
## Summary

- Allow `livewire/livewire` `^4.0` in `composer.json` (in addition to `^3.0`)
- Remove the "Remove Livewire for unsupported Laravel versions" CI step, since Livewire 4 supports Laravel 13