### PR TITLE
Treat a "0" honeypot value as spam

### DIFF
--- a/src/SpamProtection.php
+++ b/src/SpamProtection.php
@@ -33,7 +33,7 @@ class SpamProtection
 
         $honeypotValue = $requestFields->get($nameFieldName);
 
-        if (! empty($honeypotValue)) {
+        if (! in_array($honeypotValue, [null, ''], true)) {
             throw new SpamException();
         }
 

--- a/tests/ProtectAgainstSpamTest.php
+++ b/tests/ProtectAgainstSpamTest.php
@@ -79,6 +79,14 @@ test('requests that post the honeypot name field with content do not succeed', f
         ->assertDidNotPassSpamProtection();
 });
 
+test('requests that post a falsy string value for the honeypot name field do not succeed', function () {
+    $nameField = config('honeypot.name_field_name');
+
+    $this
+        ->post('test', [$nameField => '0'])
+        ->assertDidNotPassSpamProtection();
+});
+
 test('requests will always succeed when the package is not enabled', function () {
     config()->set('honeypot.enabled', false);
 


### PR DESCRIPTION
A bot that filled the honeypot field with `"0"` passed the spam check. `SpamProtection` used `! empty($honeypotValue)`, and `empty("0")` is `true` in PHP (same for `0`, `0.0`, `false`), so the `SpamException` was never thrown.

This compares against `null` and `""` instead, so only a genuinely blank field passes. A real user posts `""` for the hidden input and is unaffected.

Reported in #160.